### PR TITLE
Add disable hyperindices function and find related indicex

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NDTensors = "23ae76d9-e61a-49c4-8f12-3f1a16adf9cf"
+OMEinsum = "ebe7aa44-baf0-506c-a96f-8464559b3922"
 TestSetExtensions = "98d24dd4-01ad-11ea-1b02-c9a08f80db04"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QXTns"
 uuid = "995e1dad-72e3-4b97-b122-7deaeb8b44f9"
 authors = ["QuantEx team"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/mock_tensor.jl
+++ b/src/mock_tensor.jl
@@ -5,61 +5,22 @@ can be used for tracking the dimension of contractions which would not be possib
 storing all the data.
 """
 
-using NDTensors
 using ITensors
 
 export MockTensor
 
 
 """ Tensor store struct that just tracks tensor dimensions"""
-struct MockTensor <: NDTensors.TensorStorage{ComplexF64}
-    size::Array{Int64, 1}
+struct MockTensor{T,N} <: AbstractArray{T, N}
+    size::NTuple{N, Int}
 end
 
-MockTensor(size::NTuple{N, Int64}) where N = MockTensor(collect(size))
+MockTensor(size::NTuple{N, Int64}) where N = MockTensor{ComplexF64, N}(size)
 
 """Overload functions from base to make MockTensor usable"""
-Base.copy(a::MockTensor) = MockTensor(a.size)
+Base.copy(a::MockTensor{T, N}) where {T, N} = MockTensor{T, N}(a.size)
 Base.length(a::MockTensor) = prod(size(a))
 Base.size(a::MockTensor) = a.size
 Base.getindex(::MockTensor, ::Int64) = NaN
 Base.getindex(::MockTensor, i...) = NaN
-NDTensors.tensor(a::MockTensor, inds) = NDTensors.Tensor{ComplexF64, length(inds), MockTensor, ITensors.IndexSet}(inds, a)
-Base.getindex(::NDTensors.Tensor{ComplexF64, N, StoreT, IndsT}, ::Any) where {ComplexF64, N , StoreT <: MockTensor, IndsT} = NaN
-Base.getindex(::NDTensors.Tensor{ComplexF64, N, StoreT, IndsT}, i...) where {ComplexF64, N , StoreT <: MockTensor, IndsT} = NaN
 Base.show(io::IO, ::MIME"text/plain", a::MockTensor) = print(io, "MockTensor with dims $(Tuple(a.size))")
-
-
-"""
-    mock_contract(T1::NDTensors.Tensor,
-                  labelsT1,
-                  T2::NDTensors.Tensor,
-                  labelsT2,
-                  labelsR = NDTensors.contract_labels(labelsT1, labelsT2))
-
-Overloaded contract function from NDTensors which implements
-contraction for tensors using MockTensor objects as storage.
-"""
-function mock_contract(T1::NDTensors.Tensor,
-                       labelsT1,
-                       T2::NDTensors.Tensor,
-                       labelsT2,
-                       labelsR = NDTensors.contract_labels(labelsT1, labelsT2))
-    
-    final_dims = zeros(Int64, length(labelsR))
-    T1_dims, T2_dims = size(T1), size(T2)
-    final_inds = Array{ITensors.Index}(undef, length(labelsR))
-
-    for (dims, labels, inds) in zip([T1_dims, T2_dims], [labelsT1, labelsT2], [T1.inds, T2.inds])
-        for (i, li) in enumerate(labels)
-            pos = findfirst(x -> x == li, labelsR)
-            if pos !== nothing
-                final_dims[pos] = dims[i]
-                final_inds[pos] = inds[i]
-            end
-        end
-    end
-    tensor_store = MockTensor(final_dims)
-
-    return NDTensors.Tensor(tensor_store, final_inds)
-end

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -94,7 +94,8 @@ is returned.
 """
 function tensor_data(tensor::QXTensor; consider_hyperindices::Bool=true)
     data = store(tensor)
-    if consider_hyperindices
+    hi = hyperindices(tensor)
+    if consider_hyperindices || length(hi) == 0
         # data is stored in reduced form
         return data
     else
@@ -103,12 +104,17 @@ function tensor_data(tensor::QXTensor; consider_hyperindices::Bool=true)
     end
 end
 
+"""
+    indices2ranks(tensor::QXTensor, hi::Vector{<:Vector{<:Index}})
+
+Function convert groups of indices to groups of ranks of those indices.
+"""
 function indices2ranks(tensor::QXTensor, hi::Vector{<:Vector{<:Index}})
     # create an array of the ranks from the groups of hyper indices
     hi_ranks = Array{Int64, 1}[]
     all_indices = inds(tensor)
     for group in hi
-        push!(hi_ranks, map(x -> findfirst(y -> y == x, all_indices) ,group))
+        push!(hi_ranks, sort(map(x -> findfirst(y -> y == x, all_indices) ,group)))
     end
     hi_ranks
 end
@@ -138,7 +144,9 @@ Function to disable use of hyper indices with this tensor by removing the hyper
 indices and reshaping storage
 """
 function disable_hyperindices!(t::QXTensor)
-    t.storage = collect(expand_tensor(t.storage, t.hyper_indices))
-    empty!(t.hyper_indices)
+    if length(t.hyper_indices) > 0
+        t.storage = collect(expand_tensor(t.storage, t.hyper_indices))
+        empty!(t.hyper_indices)
+    end
     nothing
 end

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -156,18 +156,17 @@ end
                            b_indices::Array{<:Index, 1},
                            b_hyper_indices::Array{<:Array{<:Index, 1}, 1})
 
-This function calculates the resulting groups of hyper indices after contracting tensors with the given
-groups of hyper indices.
+This function calculates the resulting groups of hyper indices after contracting tensors
+with the given groups of hyper indices.
 """
 function contract_hyper_indices(a_indices::Array{<:Index, 1},
                                 a_hyper_indices::Array{<:Array{<:Index, 1}, 1},
                                 b_indices::Array{<:Index, 1},
                                 b_hyper_indices::Array{<:Array{<:Index, 1}, 1})
 
-    ag = [a_hyper_indices..., b_hyper_indices...]
-    fg = Array{Array{Index, 1}, 1}()
+    ag = [a_hyper_indices..., b_hyper_indices...] # all groups
+    fg = Array{Array{Index, 1}, 1}() # final groups
 
-    # @show all_groups
     while length(ag) > 1
         overlapping = findall(x -> length(intersect(ag[1], x)) > 0, ag[2:end]) .+ 1 # add one for slice offset
         if length(overlapping) == 0
@@ -185,12 +184,9 @@ function contract_hyper_indices(a_indices::Array{<:Index, 1},
 
     # now check that final groups still exist after contraction
     common_indices = intersect(a_indices, b_indices)
-    remaining_indices = setdiff(union(a_indices, b_indices), common_indices)
     fg = map(x -> setdiff(x, common_indices), fg)
     filter(x -> length(x) > 1, fg)
 end
-
-
 
 """
     contract_tensors(A::QXTensor, B::QXTensor; mock::Bool=false)

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -89,7 +89,7 @@ QXTensor(t::Union{Nothing, <: AbstractArray}; kwargs...) =
 Get the data associated with the given tensor. If the consider_hyperindices flag is true
 then the rank is reduced to merge related indices. For example for a 5 rank tensor where
 the 2nd and 4th indices form a group of hyper indices, with this option set to true would
-return a rank 4 tensor where the 2nd index. With hyperindices set to false a rank 5 tensor
+return a rank 4 tensor where the 2nd index has been merged with the 4th. With `consider_hyperindices` set to false a rank 5 tensor
 is returned.
 """
 function tensor_data(tensor::QXTensor; consider_hyperindices::Bool=true)

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -107,7 +107,7 @@ end
 """
     indices2ranks(tensor::QXTensor, hi::Vector{<:Vector{<:Index}})
 
-Function convert groups of indices to groups of ranks of those indices.
+Function convert groups of indices to groups of index positions (ranks).
 """
 function indices2ranks(tensor::QXTensor, hi::Vector{<:Vector{<:Index}})
     # create an array of the ranks from the groups of hyper indices

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -1,6 +1,6 @@
 using ITensors
-using NDTensors
 using LinearAlgebra
+using NDTensors
 
 """
 Tensor data structure for representing tensors and keeping track of hyper indices.
@@ -9,11 +9,11 @@ Tensor data structure for representing tensors and keeping track of hyper indice
 export QXTensor, Index, hyperindices, contract_tensors, tensor_data
 
 """Datastructure representing tensors"""
-struct QXTensor
+mutable struct QXTensor
     rank::Int64
     indices::Array{<:Index}
     hyper_indices::Array{Array{Int64, 1}, 1}
-    storage::NDTensors.TensorStorage
+    storage::AbstractArray
 end
 
 """Custom show for QXTensors"""
@@ -34,116 +34,83 @@ ITensors.store(a::QXTensor) = a.storage
 """
     QXTensor(a::T) where T <: Number
 
-
 QXTensor constructor which creates a new instance of QXTensor corresponding to a scalar
 """
-function QXTensor(a::T) where T <: Number
-    QXTensor(0, Array{Index, 1}(), Array{Array{Index, 1}, 1}(), NDTensors.Dense([a]))
+function QXTensor(a::Number)
+    QXTensor(0, Array{Index, 1}(), Array{Array{Index, 1}, 1}(), fill(a, ()))
 end
 
 """
     QXTensor(indices::Vector{<:Index},
-             hyper_indices::Vector{<:Vector{Int64}},
-             storage::Union{Nothing, <: NDTensors.TensorStorage}=nothing)
+             hyper_indices::Union{Nothing, Vector{<:Vector{Int64}}},
+             storage::Union{Nothing, <: AbstractArray}=nothing;
+             diagonal_check::Bool=true)
 
-QXTensor constructor which creates a new instance of QXTensor with the given indices
-and hyper indices. If no storage data structure is given then MockTensor of that shape
-is added as the storage.
+QXTensor constructor creates a new instance of QXTensor with the given indices
+and hyper indices. If no storage data structure is given then a MockTensor of that shape
+is added as the storage. If diagonal_check is true, it will automaticallly check which indices are hyper indices
+and record in the hyper_indices field. If hyper_indices are given, then these are used.
 """
 function QXTensor(indices::Vector{<:Index},
-                  hyper_indices::Vector{<:Vector{Int64}},
-                  storage::Union{Nothing, <: NDTensors.TensorStorage}=nothing)
+                  hyper_indices::Union{Nothing, Vector{<:Vector{Int64}}}=nothing,
+                  storage::Union{Nothing, <: AbstractArray}=nothing;
+                  diagonal_check::Bool=true)
     if storage === nothing
-        storage = MockTensor(dim.(indices))
+        storage = MockTensor(Tuple(dim.(indices)))
     end
+
+    # if hyper indices not given, diagonal check enabled and not mock tensor,
+    # then attempt to detect hyperindices directly from the tensor
+    if !(storage isa MockTensor)
+        if diagonal_check && hyper_indices === nothing
+            hyper_indices = find_hyper_edges(storage)
+        end
+        # if it is not already in reduced form then we reduce it
+        if length(hyper_indices) > 0 && ndims(storage) == length(indices)
+            storage = reduce_tensor(storage, hyper_indices)
+        end
+    end
+
+    if hyper_indices === nothing
+        hyper_indices = Vector{Vector{Int64}}()
+    end
+
     QXTensor(length(indices), indices, hyper_indices, storage)
 end
 
-"""
-    QXTensor(indices::Array{<:Index, 1})
-
-QXTensor constructor to create an instance of QXTensor with the given indices and
-will use MockTensor for the data storage.
-"""
-function QXTensor(indices::Array{<:Index, 1})
-    QXTensor(indices, Array{Array{Int64, 1}, 1}())
-end
+QXTensor(i::Vector{<:Index}, t::Union{Nothing, <: AbstractArray}; kwargs...) =
+         QXTensor(i, nothing, t; kwargs...)
+QXTensor(t::Union{Nothing, <: AbstractArray}; kwargs...) =
+         QXTensor([Index(x) for x in size(t)], nothing, t; kwargs...)
 
 """
-    QXTensor(data::AbstractArray{Elt, N},
-             indices::Vector{<:Index}
-             hyper_indices::Union{Nothing, Vector{Vector{<:Integer}}}=nothing;
-             diagonal_check::Bool=true) where {Elt, N}
-
-Constructor to create a QXTensor instance using the given data and indices. If
-diagonal_check is true, it will automaticallly check which indices are hyper indices
-and record in the hyper_indices field.
-"""
-function QXTensor(data::AbstractArray{Elt, N},
-                  indices::Vector{<:Index},
-                  hyper_indices::Union{Nothing, Vector{<:Vector{<:Integer}}}=nothing;
-                  diagonal_check::Bool=true) where {Elt, N}
-    @assert prod(size(data)) == prod(dim.(indices)) "Product of index dimensions must match data dimension"
-
-    # if hyper indices not given, diagonal check enabled and not mock tensor, then attempt to detect hyperindices
-    # directly from tensor
-    if hyper_indices === nothing
-        if diagonal_check && !(data isa MockTensor)
-            hyper_indices = find_hyper_edges(reshape(data, Tuple(dim.(indices))))
-        else
-            hyper_indices = Vector{Vector{Int64}}()
-        end
-    end
-
-    if !(data isa NDTensors.Dense) && !(data isa MockTensor)
-        data = NDTensors.Dense(reshape(data, prod(size(data))))
-    end
-    QXTensor(indices, hyper_indices, data)
-end
-
-"""
-    Base.convert(::Type{ITensor}, t::QXTensor)
-
-Overloaded convert to enable conversion of a QXTensor to an ITensor. Note that doing this
-will mean that information about the hyper indices will be lost.
-"""
-function Base.convert(::Type{ITensor}, t::QXTensor)
-    ITensor(t.storage, IndexSet(t.indices))
-end
-
-"""
-    Base.convert(::Type{QXTensor}, t::ITensor{N}) where N
-
-Overloaded convert to enable conversion of an ITensor to a QXTensor. Note that converting
-in this way means that hyper indices won't be identified.
-"""
-function Base.convert(::Type{QXTensor}, t::ITensor{N}) where N
-    QXTensor(store(t), collect(inds(t)))
-end
-
-"""
-    tensor_data(tensor::QXTensor; consider_hyperindices::Bool=false)
+    tensor_data(tensor::QXTensor; consider_hyperindices::Bool=true)
 
 Get the data associated with the given tensor. If the consider_hyperindices flag is true
-then only the first of the hyper indices are retained. For example for a 5 rank tensor where
+then the rank is reduced to merge related indices. For example for a 5 rank tensor where
 the 2nd and 4th indices form a group of hyper indices, with this option set to true would
-return a rank 4 tensor where the 2nd index
+return a rank 4 tensor where the 2nd index. With hyperindices set to false a rank 5 tensor
+is returned.
 """
-function tensor_data(tensor::QXTensor; consider_hyperindices::Bool=false)
-    tensor_dims = Tuple([dim(x) for x in inds(tensor)])
-    data = reshape(convert(Array, store(tensor)), tensor_dims)
+function tensor_data(tensor::QXTensor; consider_hyperindices::Bool=true)
+    data = store(tensor)
     if consider_hyperindices
-        hi = hyperindices(tensor)
-        # create an array of the ranks from the groups of hyper indices
-        hi_ranks = Array{Int64, 1}[]
-        all_indices = inds(tensor)
-        for group in hi
-            push!(hi_ranks, map(x -> findfirst(y -> y == x, all_indices) ,group))
-        end
-        return reduce_tensor(data, hi_ranks)
-    else
+        # data is stored in reduced form
         return data
+    else
+        hi_ranks = indices2ranks(tensor, hyperindices(tensor))
+        return collect(expand_tensor(data, hi_ranks))
     end
+end
+
+function indices2ranks(tensor::QXTensor, hi::Vector{<:Vector{<:Index}})
+    # create an array of the ranks from the groups of hyper indices
+    hi_ranks = Array{Int64, 1}[]
+    all_indices = inds(tensor)
+    for group in hi
+        push!(hi_ranks, map(x -> findfirst(y -> y == x, all_indices) ,group))
+    end
+    hi_ranks
 end
 
 """
@@ -165,61 +132,13 @@ function hyperindices(t::QXTensor; all_indices=false)
 end
 
 """
-    contract_hyper_indices(a_indices::Array{<:Index, 1},
-                           a_hyper_indices::Array{<:Array{<:Index, 1}, 1},
-                           b_indices::Array{<:Index, 1},
-                           b_hyper_indices::Array{<:Array{<:Index, 1}, 1})
+    disable_hyperindices!(t::QXTensor)
 
-This function calculates the resulting groups of hyper indices after contracting tensors
-with the given groups of hyper indices.
+Function to disable use of hyper indices with this tensor by removing the hyper
+indices and reshaping storage
 """
-function contract_hyper_indices(a_indices::Array{<:Index, 1},
-                                a_hyper_indices::Array{<:Array{<:Index, 1}, 1},
-                                b_indices::Array{<:Index, 1},
-                                b_hyper_indices::Array{<:Array{<:Index, 1}, 1})
-
-    ag = [a_hyper_indices..., b_hyper_indices...] # all groups
-    fg = Array{Array{Index, 1}, 1}() # final groups
-
-    while length(ag) > 1
-        overlapping = findall(x -> length(intersect(ag[1], x)) > 0, ag[2:end]) .+ 1 # add one for slice offset
-        if length(overlapping) == 0
-            push!(fg, ag[1])
-            popat!(ag, 1)
-        end
-        for i in sort(overlapping, rev=true)
-            ag[1] = union(ag[1], ag[i])
-            popat!(ag, i)
-        end
-    end
-    if length(ag) == 1
-        push!(fg, ag[1])
-    end
-
-    # now check that final groups still exist after contraction
-    common_indices = intersect(a_indices, b_indices)
-    fg = map(x -> setdiff(x, common_indices), fg)
-    filter(x -> length(x) > 1, fg)
-end
-
-"""
-    contract_tensors(A::QXTensor, B::QXTensor; mock::Bool=false)
-
-Function to contract two QXTensors and return another QXTensor. If the mock flag
-is false or either of the input tensors use MockTensor then the storage for the final
-tensor will be of type MockTensor.
-"""
-function contract_tensors(A::QXTensor, B::QXTensor; mock::Bool=false)
-    (labelsA,labelsB) = ITensors.compute_contraction_labels(IndexSet(inds(A)),IndexSet(inds(B)))
-    if mock || (store(A) isa MockTensor) || store(B) isa MockTensor
-        CT = mock_contract(ITensors.tensor(store(A), inds(A)), labelsA, ITensors.tensor(store(B), inds(B)), labelsB)
-    else
-        CT = contract(ITensors.tensor(store(A), IndexSet(inds(A))), labelsA, ITensors.tensor(store(B), IndexSet(inds(B))), labelsB)
-    end
-    # TODO: cleanup this logic and possibly store the indices themselves rather than positions in the struct
-    c_hyper_indices = contract_hyper_indices(inds(A), hyperindices(A), inds(B), hyperindices(B))
-    c_indices = collect(inds(CT))
-    c_hyper_indices_positions = convert(Array{Array{Int64, 1}, 1}, [findall(x -> x in y, c_indices) for y in c_hyper_indices])
-    C = QXTensor(c_indices, c_hyper_indices_positions, store(CT))
-    return C
+function disable_hyperindices!(t::QXTensor)
+    t.storage = collect(expand_tensor(t.storage, t.hyper_indices))
+    empty!(t.hyper_indices)
+    nothing
 end

--- a/src/tensor_network.jl
+++ b/src/tensor_network.jl
@@ -8,7 +8,7 @@ using OMEinsum
 export next_tensor_id!
 export TensorNetwork, bonds, simple_contraction, simple_contraction!, neighbours
 export decompose_tensor!, replace_with_svd!
-export contract_tn!, contract_pair!, replace_tensor_symbol!, contract_ncon_indices
+export contract_tn!, contract_pair!, replace_tensor_symbol!
 export get_hyperedges, disable_hyperindices!, find_connected_indices
 export contraction_indices, contract_pair
 
@@ -442,43 +442,6 @@ function Base.delete!(tn::TensorNetwork, tensor_id::Symbol)
         filter!(id -> id ≠ tensor_id, tn.bond_map[index])
     end
     delete!(tn.tensor_map, tensor_id)
-end
-
-"""
-    contract_ncon_indices(tn::TensorNetwork, A_sym::Symbol, B_sym)
-
-Function return indices in ncon format for contraction of tensors with given symbols.
-Returns two tuples for indices in each with convention that negative values are remaining
-indices and positive values are indices being contracted over.
-
-For example if (1, -1), (-2, 1) is returned, this menas that the first index of tensor A
-A is contracted with the second index of  tensor B and the resulting tensor will have
-indices corresponding to the second index of the first tensor and first index of the second
-tensor.
-"""
-function contract_ncon_indices(tn::TensorNetwork, A_sym::Symbol, B_sym::Symbol)
-    _contract_ncon_indices(IndexSet(inds(tn[A_sym])), IndexSet(inds(tn[B_sym])))
-end
-
-"""
-    _contract_ncon_indices(A_inds::IndexSet{M}, B_inds::IndexSet{N}) where {M, N}
-
-Function return indices in ncon format for contraction of tensors with given index sets.
-Returns two tuples for indices in each with convention that negative values are remaining
-indices and positive values are indices being contracted over.
-
-For example if (1, -1), (-2, 1) is returned, this menas that the first index of tensor A
-A is contracted with the second index of  tensor B and the resulting tensor will have
-indices corresponding to the second index of the first tensor and first index of the second
-tensor.
-"""
-function _contract_ncon_indices(A_inds::IndexSet{M}, B_inds::IndexSet{N}) where {M, N}
-    labels = ITensors.compute_contraction_labels(A_inds, B_inds)
-    # ITensors uses a different convention with negatie and positive reversed and
-    # find lowest positive
-    all_positive_labels = [x for x in vcat(collect.(labels)...) if x > 0]
-    offset = length(all_positive_labels) > 0 ? minimum(all_positive_labels) - 1 : 0
-    [Tuple([x > 0 ? -(x - offset) : -x for x in ls]) for ls in labels]
 end
 
 """

--- a/src/tensor_network.jl
+++ b/src/tensor_network.jl
@@ -117,10 +117,8 @@ function tensor_data(tn::TensorNetwork, i::Symbol; consider_hyperindices=true, g
                 local_hi_ranks = indices2ranks(tn[i], local_hi)
                 t = expand_tensor(t, local_hi_ranks)
             end
-            if length(global_hi) > 0
-                global_hi_ranks = indices2ranks(tn[i], global_hi)
-                t = reduce_tensor(t, global_hi_ranks)
-            end
+            global_hi_ranks = indices2ranks(tn[i], global_hi)
+            t = reduce_tensor(t, global_hi_ranks)
             return t
         end
     end

--- a/src/tensor_network.jl
+++ b/src/tensor_network.jl
@@ -410,7 +410,7 @@ end
 
 Given a tensor network and an index in the network, find all indices that are related via hyper edge
 relations. Involves recurisively checking bonds connected to neighbouring tensors of any newly
-related edges found. Returns an array in all edges in the group including the intial edge.
+related edges found. Returns an array of all edges in the group including the initial edge.
 """
 function find_connected_indices(tn::TensorNetwork, bond::Index)
     tensors_to_visit = Set{Symbol}()

--- a/src/tensor_network.jl
+++ b/src/tensor_network.jl
@@ -304,7 +304,7 @@ end
     contraction_indices(tn::TensorNetwork, a_sym::Symbol, b_sym::Symbol)
 
 Function to work out the contraction indices that would be used to contract the given
-tensors. Exptected indices in Einstein notation using positive integers
+tensors. Expected indices in Einstein notation using positive integers
 """
 function contraction_indices(tn::TensorNetwork, a_sym::Symbol, b_sym::Symbol)
     a_indices = hyperindices(tn, a_sym; all_indices=true)

--- a/src/tensor_network_circuit.jl
+++ b/src/tensor_network_circuit.jl
@@ -65,6 +65,7 @@ output_indices(tnc::TensorNetworkCircuit) = tnc.output_indices
 bonds(tnc::TensorNetworkCircuit) = bonds(tnc.tn)
 qubits(tnc::TensorNetworkCircuit) = tnc.qubits
 tensor_data(tnc::TensorNetworkCircuit, i; kwargs...) = tensor_data(tnc.tn, i; kwargs...)
+hyperindices(tnc::TensorNetworkCircuit, i; kwargs...) = hyperindices(tnc.tn, i; kwargs...)
 get_hyperedges(tnc::TensorNetworkCircuit) = get_hyperedges(tnc.tn)
 disable_hyperindices!(tnc::TensorNetworkCircuit) = disable_hyperindices!(tnc.tn)
 

--- a/src/tensor_network_circuit.jl
+++ b/src/tensor_network_circuit.jl
@@ -66,6 +66,7 @@ bonds(tnc::TensorNetworkCircuit) = bonds(tnc.tn)
 qubits(tnc::TensorNetworkCircuit) = tnc.qubits
 tensor_data(tnc::TensorNetworkCircuit, i) = tensor_data(tnc.tn, i)
 get_hyperedges(tnc::TensorNetworkCircuit) = get_hyperedges(tnc.tn)
+disable_hyperindices!(tnc::TensorNetworkCircuit) = disable_hyperindices!(tnc.tn)
 
 
 """

--- a/src/tensor_network_circuit.jl
+++ b/src/tensor_network_circuit.jl
@@ -64,7 +64,7 @@ input_indices(tnc::TensorNetworkCircuit) = tnc.input_indices
 output_indices(tnc::TensorNetworkCircuit) = tnc.output_indices
 bonds(tnc::TensorNetworkCircuit) = bonds(tnc.tn)
 qubits(tnc::TensorNetworkCircuit) = tnc.qubits
-tensor_data(tnc::TensorNetworkCircuit, i) = tensor_data(tnc.tn, i)
+tensor_data(tnc::TensorNetworkCircuit, i; kwargs...) = tensor_data(tnc.tn, i; kwargs...)
 get_hyperedges(tnc::TensorNetworkCircuit) = get_hyperedges(tnc.tn)
 disable_hyperindices!(tnc::TensorNetworkCircuit) = disable_hyperindices!(tnc.tn)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -205,7 +205,7 @@ Base.show(io::IO, ::MIME"text/plain", a::BlockTensor) =
 Function to expand the rank of the given tensor assuming the given hyper edge groups.
 Like a generalisation of Diagonal (but returns the full dense tensor). For example
 if passed a vector and given hyperindex groups [1,2], it will return a matrix
-with where non diagonal elements are zero. Efficiency could be improved by creating
+where non diagonal elements are zero. Efficiency could be improved by creating
 a datastructure that implements
 
 ```

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -203,16 +203,13 @@ Base.show(io::IO, ::MIME"text/plain", a::BlockTensor) =
     expand_tensor(A::AbstractArray{Elt, N}, hyper_index_groups::Array{Int64, 1})
 
 Function to expand the rank of the given tensor assuming the given hyper edge groups.
-Like a generalisation of Diagonal (but returns the full dense tensor). For example
-if passed a vector and given hyperindex groups [1,2], it will return a matrix
-where non diagonal elements are zero. Efficiency could be improved by creating
-a datastructure that implements
+Like a generalisation of Diagonal. For example if passed a vector and given hyperindex
+groups [1,2], it will return a matrix where non diagonal elements are zero. Returns a
+a BlockTensor object which does not store "off-diagonal" elements.
 
 ```
 julia> expand_tensor([1, 2], [[1, 2]])
-2×2 Matrix{Int64}:
- 1  0
- 0  2
+BlockTensor with dims (2, 2) and index map (1, 1)
 ```
 """
 function expand_tensor(A::AbstractArray{Elt, N}, hyper_index_groups::Array{Array{Int64, 1}, 1}) where {Elt, N}

--- a/test/test_tensor.jl
+++ b/test/test_tensor.jl
@@ -16,6 +16,7 @@ using LinearAlgebra
     indices = [Index(2), Index(2), Index(2), Index(2)]
     a = QXTensor(data, indices)
     @test hyperindices(a) == [indices[[2, 4]]]
+    @test hyperindices(a, all_indices=true) == [[indices[1]], indices[[2, 4]], [indices[3]]]
 
     data = reshape(Diagonal(ones(4)), (2, 2, 2 ,2))
     indices = [Index(2), Index(2), Index(2), Index(2)]

--- a/test/test_tensor.jl
+++ b/test/test_tensor.jl
@@ -8,74 +8,87 @@ using LinearAlgebra
     # test hyper edge search
     data = Diagonal(ones(4))
     indices = [Index(4), Index(4)]
-    a = QXTensor(data, indices)
+    a = QXTensor(indices, data)
     @test size(a) == (4, 4)
     @test hyperindices(a) == [indices]
 
     data = reshape(QXTns.Gates.cx(), (2, 2, 2 ,2))
     indices = [Index(2), Index(2), Index(2), Index(2)]
-    a = QXTensor(data, indices)
+    a = QXTensor(indices, data)
     @test hyperindices(a) == [indices[[2, 4]]]
     @test hyperindices(a, all_indices=true) == [[indices[1]], indices[[2, 4]], [indices[3]]]
 
     data = reshape(Diagonal(ones(4)), (2, 2, 2 ,2))
     indices = [Index(2), Index(2), Index(2), Index(2)]
-    a = QXTensor(data, indices)
+    a = QXTensor(indices, data)
     @test hyperindices(a) == [indices[[1, 3]], indices[[2, 4]]]
 end
 
-@testset "Test contraction of hyper indices" begin
+@testset "Test contraction of tensors with hyper indices" begin
     # we create two sets of indices and identify subsets of indices that are hyper indices
     # we then contract over these sets to ensure the results set has the expected hyper indices
     as = [Index(2), Index(2), Index(2), Index(2)]
-    a_hyper_indices = [[as[1], as[3]]]
+    a_hyper_indices = [[1, 3]]
+    a = QXTensor(as, a_hyper_indices)
     bs = [as[3], as[4], Index(2), Index(2)]
-    b_hyper_indices = [[bs[1], bs[3]]]
+    b_hyper_indices = [[1, 3]]
+    b = QXTensor(bs, b_hyper_indices)
 
-    @test QXTns.contract_hyper_indices(as, a_hyper_indices, bs, b_hyper_indices) == [[as[1], bs[3]]]
+    c = contract_tensors(a, b)
+    @test Set(hyperindices(c)...) == Set([as[1], bs[3]])
 
     # now an example with two sets of hyper indices
     as = [Index(2), Index(2), Index(2), Index(2)]
-    a_hyper_indices = [[as[1], as[3]], [as[2], as[4]]]
+    a_hyper_indices = [[1, 3], [2, 4]]
+    a = QXTensor(as, a_hyper_indices)
     bs = [as[3], as[4], Index(2), Index(2)]
-    b_hyper_indices = [[bs[1], bs[3]], [bs[2], bs[4]]]
+    b_hyper_indices = [[1, 3], [2, 4]]
+    b = QXTensor(bs, b_hyper_indices)
 
-    @test QXTns.contract_hyper_indices(as, a_hyper_indices, bs, b_hyper_indices) == [[as[1], bs[3]], [as[2], bs[4]]]
+    c = contract_tensors(a, b)
+    @test Set(hyperindices(c)[1]) == Set([as[1], bs[3]])
+    @test Set(hyperindices(c)[2]) == Set([as[2], bs[4]])
 
     # next an example where the first tensor will have a group of hyper indices remaining
     # but the second tensor won't
-    as = [Index(2), Index(2), Index(2), Index(2), Index(5)]
-    a_hyper_indices = [[as[1], as[2], as[3]]]
+    as = [Index(2), Index(2), Index(2), Index(5), Index(5)]
+    a_hyper_indices = [[1, 2, 3]]
+    a = QXTensor(as, a_hyper_indices)
     bs = [as[1], Index(4), Index(5), as[4]]
-    b_hyper_indices = [[bs[3], bs[4]]]
+    b_hyper_indices = [[3, 4]]
+    b = QXTensor(bs, b_hyper_indices)
 
-    @test QXTns.contract_hyper_indices(as, a_hyper_indices, bs, b_hyper_indices) == [[as[2], as[3]]]
+    c = contract_tensors(a, b)
+    @test Set(hyperindices(c)[1]) == Set([as[2], as[3]])
 
     # next an example where the first tensor has two groups linked with group from second tensor
     as = [Index(2), Index(2), Index(2), Index(2)]
-    a_hyper_indices = [[as[1], as[2]], [as[3], as[4]]]
+    a_hyper_indices = [[1, 2], [3, 4]]
+    a = QXTensor(as, a_hyper_indices)
     bs = [as[1], as[4]]
-    b_hyper_indices = [[bs[1], bs[2]]]
+    b_hyper_indices = [[1, 2]]
+    b = QXTensor(bs, b_hyper_indices)
 
-    @test QXTns.contract_hyper_indices(as, a_hyper_indices, bs, b_hyper_indices) == [[as[2], as[3]]]
+    c = contract_tensors(a, b)
+    @test Set(hyperindices(c)[1]) == Set([as[2], as[3]])
 end
 
 @testset "Test tensor_data when considering hyperedges" begin
     # test a diagonal
     data = Diagonal(ones(4))
     indices = [Index(4), Index(4)]
-    a = QXTensor(data, indices)
+    a = QXTensor(indices, data)
     @test tensor_data(a, consider_hyperindices=true) == ones(4)
 
     # test a rank 4 tensor with 2 sets of hyper edges
     data = reshape(Diagonal(ones(4)), (2, 2, 2 ,2))
     indices = [Index(2), Index(2), Index(2), Index(2)]
-    a = QXTensor(data, indices)
+    a = QXTensor(indices, data)
     @test tensor_data(a, consider_hyperindices=true) == ones(2, 2)
 
     # test a 2x2x2 tensor with single group of hyper edges include all ranks
     data = zeros(2, 2, 2)
     for i in 1:2 data[i, i, i] = 1 end
-    a = QXTensor(data, [Index(2), Index(2), Index(2)])
+    a = QXTensor([Index(2), Index(2), Index(2)], data)
     @test tensor_data(a, consider_hyperindices=true) == ones(2)
 end

--- a/test/test_tn.jl
+++ b/test/test_tn.jl
@@ -237,13 +237,39 @@ end
     @test length(setdiff(find_connected_indices(tn, ai[3]), [ai[3], bi[3]])) == 0
 
     # look at case of global connection of hyper indices
-    ai = [Index(2) for _ in 1:4]
-    bi = [ai[3], ai[4], Index(2), Index(2)]
-
     a = QXTensor(ai, [[1,3], [2,4]])
     b = QXTensor(bi, [[1,2], [3,4]])
     tn = TensorNetwork([a, b])
     # now ai[1] and ai[2] shoudl be connected the indices in b are related there
     group = find_connected_indices(tn, ai[1])
     @test ai[2] ∈ group
+end
+
+@testset "Test hyperindex finding when considering global hyperindices" begin
+    ai = [Index(2) for _ in 1:4]
+    bi = [ai[3], ai[4], Index(2), Index(2)]
+
+    # create a_data with hyperindex structure matching [[1,3], [2,4]]
+    a_data = rand(2,2,2,2)
+    for i in CartesianIndices((2,2,2,2))
+        if i[1] != i[3] || i[2] != i[4]
+            a_data[Tuple(i)...] = 0.
+        end
+    end
+
+    # create b_data with hyperindex structure matching [[1,2], [3,4]]
+    b_data = rand(2,2,2,2)
+    for i in CartesianIndices((2,2,2,2))
+        if i[1] != i[2] || i[3] != i[4]
+            b_data[Tuple(i)...] = 0.
+        end
+    end
+    a = QXTensor(a_data, ai)
+    b = QXTensor(b_data, bi)
+    tn = TensorNetwork([a, b])
+
+    @test length(setdiff(hyperindices(tn, first(keys(tn)))..., ai)) == 0
+    @test size(tensor_data(tn, first(keys(tn)))) == (2,)
+    @test size(tensor_data(tn, first(keys(tn)), global_hyperindices=false)) == (2, 2)
+    @test size(tensor_data(tn, first(keys(tn)), consider_hyperindices=false)) == (2,2,2,2)
 end


### PR DESCRIPTION
### Summary

Add functions which disables hyperindex account for tensor networks

### Rationale

It can be useful to disable hyperindices completely for comparison

#### Implementation Details

Add function which clears arrays of hyperindices

#### Additional notes

<hr>

***Check before merging:***

- [x] All discussions are resolved
- [x] New code is covered by appropriate tests
- [x] Tests are passing locally and on CI
- [x] The documentation is consistent with changes
- [x] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [x] Notebooks/examples not covered by unittests have been tested and updated as required
- [x] The feature branch is up-to-date with the master branch (rebase if behind)
- [x] Incremented the version string in Project.toml file
